### PR TITLE
feature: Endpoint para obtener menú agrupado por categorías

### DIFF
--- a/src/main/java/com/elpolloempoderado/backend/controller/MenuController.java
+++ b/src/main/java/com/elpolloempoderado/backend/controller/MenuController.java
@@ -1,0 +1,36 @@
+package com.elpolloempoderado.backend.controller;
+
+import com.elpolloempoderado.backend.dto.MenuCategoryResponse;
+import com.elpolloempoderado.backend.service.MenuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Controlador REST para el endpoint del menú
+ * Proporciona un endpoint optimizado para obtener todas las categorías con sus platos
+ */
+@RestController
+@RequestMapping("/api/menu")
+@RequiredArgsConstructor
+public class MenuController {
+    
+    private final MenuService menuService;
+    
+    /**
+     * GET /api/menu - Obtiene el menú completo con categorías y platos
+     * Optimizado con fetch join para minimizar consultas a la base de datos
+     * Ideal para la pantalla principal del menú en el frontend
+     * 
+     * @return Lista de categorías con sus platos asociados, ordenadas alfabéticamente
+     */
+    @GetMapping
+    public ResponseEntity<List<MenuCategoryResponse>> getFullMenu() {
+        List<MenuCategoryResponse> menu = menuService.getFullMenu();
+        return ResponseEntity.ok(menu);
+    }
+}

--- a/src/main/java/com/elpolloempoderado/backend/dto/MenuCategoryResponse.java
+++ b/src/main/java/com/elpolloempoderado/backend/dto/MenuCategoryResponse.java
@@ -1,0 +1,21 @@
+package com.elpolloempoderado.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * DTO que representa una categoría con sus platos para el menú
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuCategoryResponse {
+    
+    private Long id;
+    private String name;
+    private String description;
+    private List<MenuDishResponse> dishes;
+}

--- a/src/main/java/com/elpolloempoderado/backend/dto/MenuDishResponse.java
+++ b/src/main/java/com/elpolloempoderado/backend/dto/MenuDishResponse.java
@@ -1,0 +1,22 @@
+package com.elpolloempoderado.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * DTO simplificado de plato para el menú (sin incluir categoría para evitar redundancia)
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuDishResponse {
+    
+    private Long id;
+    private String name;
+    private String description;
+    private BigDecimal price;
+    private String imageUrl;
+}

--- a/src/main/java/com/elpolloempoderado/backend/repository/MenuRepository.java
+++ b/src/main/java/com/elpolloempoderado/backend/repository/MenuRepository.java
@@ -1,0 +1,38 @@
+package com.elpolloempoderado.backend.repository;
+
+import com.elpolloempoderado.backend.model.Category;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Repositorio especializado para consultas del menú
+ * Optimizado para obtener categorías con sus platos en una sola consulta
+ */
+@Repository
+@RequiredArgsConstructor
+public class MenuRepository {
+    
+    @PersistenceContext
+    private final EntityManager entityManager;
+    
+    /**
+     * Obtiene todas las categorías con sus platos usando fetch join para optimizar consultas
+     * DISTINCT evita duplicados por la relación OneToMany
+     * Ordenamiento dual: categorías por nombre, platos por nombre
+     * 
+     * @return Lista de categorías con platos cargados
+     */
+    public List<Category> findAllCategoriesWithDishes() {
+        String jpql = "SELECT DISTINCT c FROM Category c " +
+                     "LEFT JOIN FETCH c.dishes d " +
+                     "ORDER BY c.name ASC, d.name ASC";
+        
+        TypedQuery<Category> query = entityManager.createQuery(jpql, Category.class);
+        return query.getResultList();
+    }
+}

--- a/src/main/java/com/elpolloempoderado/backend/service/MenuService.java
+++ b/src/main/java/com/elpolloempoderado/backend/service/MenuService.java
@@ -1,0 +1,18 @@
+package com.elpolloempoderado.backend.service;
+
+import com.elpolloempoderado.backend.dto.MenuCategoryResponse;
+
+import java.util.List;
+
+/**
+ * Servicio para gestionar el menú completo con categorías y platos
+ */
+public interface MenuService {
+    
+    /**
+     * Obtiene el menú completo con todas las categorías y sus platos asociados
+     * Optimizado con fetch join para minimizar consultas a la base de datos
+     * @return Lista de categorías con sus platos, ordenadas alfabéticamente
+     */
+    List<MenuCategoryResponse> getFullMenu();
+}

--- a/src/main/java/com/elpolloempoderado/backend/service/impl/MenuServiceImpl.java
+++ b/src/main/java/com/elpolloempoderado/backend/service/impl/MenuServiceImpl.java
@@ -1,0 +1,65 @@
+package com.elpolloempoderado.backend.service.impl;
+
+import com.elpolloempoderado.backend.dto.MenuCategoryResponse;
+import com.elpolloempoderado.backend.dto.MenuDishResponse;
+import com.elpolloempoderado.backend.model.Category;
+import com.elpolloempoderado.backend.model.Dish;
+import com.elpolloempoderado.backend.repository.MenuRepository;
+import com.elpolloempoderado.backend.service.MenuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MenuServiceImpl implements MenuService {
+    
+    private final MenuRepository menuRepository;
+    
+    @Override
+    public List<MenuCategoryResponse> getFullMenu() {
+        // Obtener todas las categorías con sus platos en una sola consulta optimizada
+        List<Category> categories = menuRepository.findAllCategoriesWithDishes();
+        
+        // Convertir entidades a DTOs
+        return categories.stream()
+                .map(this::convertToMenuCategoryResponse)
+                .sorted(Comparator.comparing(MenuCategoryResponse::getName)) // Ordenar categorías por nombre
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * Convierte una entidad Category a MenuCategoryResponse
+     */
+    private MenuCategoryResponse convertToMenuCategoryResponse(Category category) {
+        List<MenuDishResponse> dishResponses = category.getDishes().stream()
+                .map(this::convertToMenuDishResponse)
+                .sorted(Comparator.comparing(MenuDishResponse::getName)) // Ordenar platos por nombre
+                .collect(Collectors.toList());
+        
+        return new MenuCategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getDescription(),
+                dishResponses
+        );
+    }
+    
+    /**
+     * Convierte una entidad Dish a MenuDishResponse
+     */
+    private MenuDishResponse convertToMenuDishResponse(Dish dish) {
+        return new MenuDishResponse(
+                dish.getId(),
+                dish.getName(),
+                dish.getDescription(),
+                dish.getPrice(),
+                dish.getImageUrl()
+        );
+    }
+}

--- a/src/test/java/com/elpolloempoderado/backend/controller/MenuControllerTest.java
+++ b/src/test/java/com/elpolloempoderado/backend/controller/MenuControllerTest.java
@@ -1,0 +1,173 @@
+package com.elpolloempoderado.backend.controller;
+
+import com.elpolloempoderado.backend.dto.MenuCategoryResponse;
+import com.elpolloempoderado.backend.dto.MenuDishResponse;
+import com.elpolloempoderado.backend.security.JwtAuthenticationFilter;
+import com.elpolloempoderado.backend.service.MenuService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        controllers = MenuController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = JwtAuthenticationFilter.class
+        )
+)
+@AutoConfigureMockMvc(addFilters = false)
+class MenuControllerTest {
+    
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @MockBean
+    private MenuService menuService;
+    
+    @Test
+    @WithMockUser
+    void testGetFullMenu_Success() throws Exception {
+        // Given
+        MenuDishResponse dish1 = new MenuDishResponse(
+                1L, "Pollo a la Brasa", "Delicioso pollo", new BigDecimal("25.99"), "http://example.com/pollo.jpg"
+        );
+        
+        MenuDishResponse dish2 = new MenuDishResponse(
+                2L, "Arroz con Pollo", "Tradicional", new BigDecimal("18.50"), "http://example.com/arroz.jpg"
+        );
+        
+        MenuCategoryResponse category1 = new MenuCategoryResponse(
+                1L, "Platos Principales", "Comidas completas", Arrays.asList(dish1, dish2)
+        );
+        
+        MenuDishResponse dish3 = new MenuDishResponse(
+                3L, "Helado", "Helado de vainilla", new BigDecimal("8.00"), "http://example.com/helado.jpg"
+        );
+        
+        MenuCategoryResponse category2 = new MenuCategoryResponse(
+                2L, "Postres", "Dulces deliciosos", Arrays.asList(dish3)
+        );
+        
+        List<MenuCategoryResponse> menu = Arrays.asList(category1, category2);
+        
+        when(menuService.getFullMenu()).thenReturn(menu);
+        
+        // When & Then
+        mockMvc.perform(get("/api/menu"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(2)))
+                
+                // Verificar primera categoría
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("Platos Principales"))
+                .andExpect(jsonPath("$[0].description").value("Comidas completas"))
+                .andExpect(jsonPath("$[0].dishes", hasSize(2)))
+                
+                // Verificar primer plato de la primera categoría
+                .andExpect(jsonPath("$[0].dishes[0].id").value(1))
+                .andExpect(jsonPath("$[0].dishes[0].name").value("Pollo a la Brasa"))
+                .andExpect(jsonPath("$[0].dishes[0].description").value("Delicioso pollo"))
+                .andExpect(jsonPath("$[0].dishes[0].price").value(25.99))
+                .andExpect(jsonPath("$[0].dishes[0].imageUrl").value("http://example.com/pollo.jpg"))
+                
+                // Verificar segundo plato de la primera categoría
+                .andExpect(jsonPath("$[0].dishes[1].id").value(2))
+                .andExpect(jsonPath("$[0].dishes[1].name").value("Arroz con Pollo"))
+                
+                // Verificar segunda categoría
+                .andExpect(jsonPath("$[1].id").value(2))
+                .andExpect(jsonPath("$[1].name").value("Postres"))
+                .andExpect(jsonPath("$[1].dishes", hasSize(1)))
+                .andExpect(jsonPath("$[1].dishes[0].name").value("Helado"));
+        
+        verify(menuService, times(1)).getFullMenu();
+    }
+    
+    @Test
+    @WithMockUser
+    void testGetFullMenu_EmptyMenu() throws Exception {
+        // Given
+        when(menuService.getFullMenu()).thenReturn(Collections.emptyList());
+        
+        // When & Then
+        mockMvc.perform(get("/api/menu"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(0)));
+        
+        verify(menuService, times(1)).getFullMenu();
+    }
+    
+    @Test
+    @WithMockUser
+    void testGetFullMenu_CategoryWithNoDishes() throws Exception {
+        // Given
+        MenuCategoryResponse emptyCategory = new MenuCategoryResponse(
+                1L, "Categoría Vacía", "Sin platos disponibles", Collections.emptyList()
+        );
+        
+        when(menuService.getFullMenu()).thenReturn(Arrays.asList(emptyCategory));
+        
+        // When & Then
+        mockMvc.perform(get("/api/menu"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("Categoría Vacía"))
+                .andExpect(jsonPath("$[0].dishes", hasSize(0)));
+        
+        verify(menuService, times(1)).getFullMenu();
+    }
+    
+    @Test
+    @WithMockUser
+    void testGetFullMenu_VerifyResponseStructure() throws Exception {
+        // Given
+        MenuDishResponse dish = new MenuDishResponse(
+                1L, "Test Dish", "Test Description", new BigDecimal("10.50"), "http://test.com/image.jpg"
+        );
+        
+        MenuCategoryResponse category = new MenuCategoryResponse(
+                1L, "Test Category", "Test Desc", Arrays.asList(dish)
+        );
+        
+        when(menuService.getFullMenu()).thenReturn(Arrays.asList(category));
+        
+        // When & Then
+        mockMvc.perform(get("/api/menu"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").exists())
+                .andExpect(jsonPath("$[0].name").exists())
+                .andExpect(jsonPath("$[0].description").exists())
+                .andExpect(jsonPath("$[0].dishes").exists())
+                .andExpect(jsonPath("$[0].dishes[0].id").exists())
+                .andExpect(jsonPath("$[0].dishes[0].name").exists())
+                .andExpect(jsonPath("$[0].dishes[0].description").exists())
+                .andExpect(jsonPath("$[0].dishes[0].price").exists())
+                .andExpect(jsonPath("$[0].dishes[0].imageUrl").exists())
+                // Verificar que NO incluye el campo category en MenuDishResponse
+                .andExpect(jsonPath("$[0].dishes[0].category").doesNotExist())
+                .andExpect(jsonPath("$[0].dishes[0].categoryId").doesNotExist());
+        
+        verify(menuService, times(1)).getFullMenu();
+    }
+}

--- a/src/test/java/com/elpolloempoderado/backend/service/impl/MenuServiceImplTest.java
+++ b/src/test/java/com/elpolloempoderado/backend/service/impl/MenuServiceImplTest.java
@@ -1,0 +1,215 @@
+package com.elpolloempoderado.backend.service.impl;
+
+import com.elpolloempoderado.backend.dto.MenuCategoryResponse;
+import com.elpolloempoderado.backend.model.Category;
+import com.elpolloempoderado.backend.model.Dish;
+import com.elpolloempoderado.backend.repository.MenuRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MenuServiceImplTest {
+    
+    @Mock
+    private MenuRepository menuRepository;
+    
+    @InjectMocks
+    private MenuServiceImpl menuService;
+    
+    @Test
+    void testGetFullMenu_WithMultipleCategoriesAndDishes() {
+        // Given
+        Category category1 = new Category();
+        category1.setId(1L);
+        category1.setName("Platos Principales");
+        category1.setDescription("Deliciosas comidas");
+        
+        Dish dish1 = new Dish();
+        dish1.setId(1L);
+        dish1.setName("Pollo a la Brasa");
+        dish1.setDescription("Delicioso pollo asado");
+        dish1.setPrice(new BigDecimal("25.99"));
+        dish1.setImageUrl("http://example.com/pollo.jpg");
+        dish1.setCategory(category1);
+        
+        Dish dish2 = new Dish();
+        dish2.setId(2L);
+        dish2.setName("Arroz con Pollo");
+        dish2.setDescription("Tradicional arroz con pollo");
+        dish2.setPrice(new BigDecimal("18.50"));
+        dish2.setImageUrl("http://example.com/arroz.jpg");
+        dish2.setCategory(category1);
+        
+        category1.getDishes().add(dish1);
+        category1.getDishes().add(dish2);
+        
+        Category category2 = new Category();
+        category2.setId(2L);
+        category2.setName("Postres");
+        category2.setDescription("Dulces deliciosos");
+        
+        Dish dish3 = new Dish();
+        dish3.setId(3L);
+        dish3.setName("Helado");
+        dish3.setDescription("Helado de vainilla");
+        dish3.setPrice(new BigDecimal("8.00"));
+        dish3.setImageUrl("http://example.com/helado.jpg");
+        dish3.setCategory(category2);
+        
+        category2.getDishes().add(dish3);
+        
+        when(menuRepository.findAllCategoriesWithDishes())
+                .thenReturn(Arrays.asList(category1, category2));
+        
+        // When
+        List<MenuCategoryResponse> menu = menuService.getFullMenu();
+        
+        // Then
+        assertThat(menu).hasSize(2);
+        
+        // Verificar primera categoría
+        MenuCategoryResponse firstCategory = menu.get(0);
+        assertThat(firstCategory.getName()).isEqualTo("Platos Principales");
+        assertThat(firstCategory.getDescription()).isEqualTo("Deliciosas comidas");
+        assertThat(firstCategory.getDishes()).hasSize(2);
+        
+        // Verificar que los platos están ordenados alfabéticamente
+        assertThat(firstCategory.getDishes().get(0).getName()).isEqualTo("Arroz con Pollo");
+        assertThat(firstCategory.getDishes().get(1).getName()).isEqualTo("Pollo a la Brasa");
+        
+        // Verificar segunda categoría
+        MenuCategoryResponse secondCategory = menu.get(1);
+        assertThat(secondCategory.getName()).isEqualTo("Postres");
+        assertThat(secondCategory.getDishes()).hasSize(1);
+        assertThat(secondCategory.getDishes().get(0).getName()).isEqualTo("Helado");
+        
+        verify(menuRepository, times(1)).findAllCategoriesWithDishes();
+    }
+    
+    @Test
+    void testGetFullMenu_WithEmptyCategories() {
+        // Given
+        Category category = new Category();
+        category.setId(1L);
+        category.setName("Categoría Vacía");
+        category.setDescription("Sin platos");
+        
+        when(menuRepository.findAllCategoriesWithDishes())
+                .thenReturn(Arrays.asList(category));
+        
+        // When
+        List<MenuCategoryResponse> menu = menuService.getFullMenu();
+        
+        // Then
+        assertThat(menu).hasSize(1);
+        assertThat(menu.get(0).getDishes()).isEmpty();
+        
+        verify(menuRepository, times(1)).findAllCategoriesWithDishes();
+    }
+    
+    @Test
+    void testGetFullMenu_WithNoCategories() {
+        // Given
+        when(menuRepository.findAllCategoriesWithDishes())
+                .thenReturn(Arrays.asList());
+        
+        // When
+        List<MenuCategoryResponse> menu = menuService.getFullMenu();
+        
+        // Then
+        assertThat(menu).isEmpty();
+        
+        verify(menuRepository, times(1)).findAllCategoriesWithDishes();
+    }
+    
+    @Test
+    void testGetFullMenu_DishesAreOrderedAlphabetically() {
+        // Given
+        Category category = new Category();
+        category.setId(1L);
+        category.setName("Test Category");
+        
+        Dish dishZ = new Dish();
+        dishZ.setId(1L);
+        dishZ.setName("Zebra Cake");
+        dishZ.setPrice(new BigDecimal("10.00"));
+        dishZ.setCategory(category);
+        
+        Dish dishA = new Dish();
+        dishA.setId(2L);
+        dishA.setName("Apple Pie");
+        dishA.setPrice(new BigDecimal("8.00"));
+        dishA.setCategory(category);
+        
+        Dish dishM = new Dish();
+        dishM.setId(3L);
+        dishM.setName("Mango Smoothie");
+        dishM.setPrice(new BigDecimal("6.00"));
+        dishM.setCategory(category);
+        
+        category.getDishes().addAll(Arrays.asList(dishZ, dishA, dishM));
+        
+        when(menuRepository.findAllCategoriesWithDishes())
+                .thenReturn(Arrays.asList(category));
+        
+        // When
+        List<MenuCategoryResponse> menu = menuService.getFullMenu();
+        
+        // Then
+        assertThat(menu).hasSize(1);
+        List<String> dishNames = menu.get(0).getDishes().stream()
+                .map(d -> d.getName())
+                .toList();
+        
+        assertThat(dishNames).containsExactly("Apple Pie", "Mango Smoothie", "Zebra Cake");
+        
+        verify(menuRepository, times(1)).findAllCategoriesWithDishes();
+    }
+    
+    @Test
+    void testGetFullMenu_VerifyDishDataIntegrity() {
+        // Given
+        Category category = new Category();
+        category.setId(1L);
+        category.setName("Test Category");
+        
+        Dish dish = new Dish();
+        dish.setId(10L);
+        dish.setName("Test Dish");
+        dish.setDescription("Test Description");
+        dish.setPrice(new BigDecimal("15.75"));
+        dish.setImageUrl("http://example.com/test.jpg");
+        dish.setCategory(category);
+        
+        category.getDishes().add(dish);
+        
+        when(menuRepository.findAllCategoriesWithDishes())
+                .thenReturn(Arrays.asList(category));
+        
+        // When
+        List<MenuCategoryResponse> menu = menuService.getFullMenu();
+        
+        // Then
+        assertThat(menu).hasSize(1);
+        assertThat(menu.get(0).getDishes()).hasSize(1);
+        
+        var dishResponse = menu.get(0).getDishes().get(0);
+        assertThat(dishResponse.getId()).isEqualTo(10L);
+        assertThat(dishResponse.getName()).isEqualTo("Test Dish");
+        assertThat(dishResponse.getDescription()).isEqualTo("Test Description");
+        assertThat(dishResponse.getPrice()).isEqualByComparingTo(new BigDecimal("15.75"));
+        assertThat(dishResponse.getImageUrl()).isEqualTo("http://example.com/test.jpg");
+        
+        verify(menuRepository, times(1)).findAllCategoriesWithDishes();
+    }
+}


### PR DESCRIPTION
## 📌 Descripción 
Implementación de un nuevo endpoint `/api/menu/` que devuelve los platos del menú agrupados por sus categorías correspondientes. Este endpoint facilita la visualización organizada del menú en el frontend, eliminando la necesidad de procesar y agrupar los datos del lado del cliente.

El endpoint retorna una estructura JSON donde cada categoría contiene su información básica y un array con todos los platos que pertenecen a ella.

Closes: #10 

---

## 🔎 Tipo de cambio
- [x] Feature (nueva funcionalidad)
- [ ] Bugfix (corrección)
- [ ] Refactorización
- [ ] Documentación
- [ ] Tests
- [ ] Otro: _______

---

## 🧾 Archivos principales modificados
```
src/main/java/com/elpolloempoaderado/backend/controller/MenuController.java
src/main/java/com/elpolloempoaderado/backend/dto/MenuCategoryResponse.java
src/main/java/com/elpolloempoaderado/backend/dto/MenuDishResponse.java
src/main/java/com/elpolloempoaderado/backend/repository/MenuRepository.java
src/main/java/com/elpolloempoaderado/backend/service/MenuService.java
src/main/java/com/elpolloempoaderado/backend/service/impl/MenuServiceImpl.java
src/test/java/com/elpolloempoaderado/backend/controller/MenuControllerTest.java
src/test/java/com/elpolloempoaderado/backend/service/impl/MenuServiceImplTest.java
```

---

## 🧪 Cómo probar (pasos reproducibles)

1. **Entorno:** Java 17+, Spring Boot 3.x, Maven, PostgreSQL/MySQL (según configuración del proyecto)
2. **Instalar dependencias:** 
   - Linux/Mac: `./mvnw clean install`
   - Windows: `mvnw.cmd clean install`
3. **Configurar base de datos:** 
   - Verificar `application.properties` o `application.yml`
   - Asegurar que las tablas `categories` y `dishes` están creadas y pobladas con datos de prueba
4. **Ejecutar la aplicación:** 
   - Línea de comandos: `./mvnw spring-boot:run`
   - IDE: Ejecutar la clase principal con anotación `@SpringBootApplication`
5. **Pasos de prueba:**
   - Realizar una petición GET a `http://localhost:8080/api/menu`
   - Usar Postman, Thunder Client, Insomnia o curl:
     ```bash
     curl -X GET http://localhost:8080/api/menu \
          -H "Content-Type: application/json"
     ```
   - Verificar que la respuesta incluya categorías con sus platos anidados
   - Probar con diferentes estados de la base de datos (con/sin datos)
   
6. **Resultado esperado:** 
   - Status HTTP 200 OK
   - JSON con estructura:
     ```json
     [
        {
          "id": 1,
          "name": "Platos Principales",
          "description": "Deliciosas comidas completas",
          "dishes": [
            {
              "id": 1,
              "name": "Arroz con Pollo",
              "description": "Tradicional arroz con pollo",
              "price": 18.50,
              "imageUrl": "http://example.com/arroz.jpg"
            },
            {
              "id": 2,
              "name": "Pollo a la Brasa",
              "description": "Delicioso pollo asado",
              "price": 25.99,
              "imageUrl": "http://example.com/pollo.jpg"
            }
          ]
        },
        {
          "id": 2,
          "name": "Postres",
          "description": "Dulces deliciosos",
          "dishes": [
            {
              "id": 3,
              "name": "Helado",
              "description": "Helado de vainilla",
              "price": 8.00,
              "imageUrl": "http://example.com/helado.jpg"
            }
          ]
        }
      ]
     ```
   - Cada categoría debe contener sus platos asociados mediante `category_id`
   - Las categorías sin platos deben mostrar un array vacío `"dishes": []`

7. **Ejecutar tests:**
   ```bash
   ./mvnw test
   ```

---

## ✅ Checklist antes del merge
- [x] Código compilado y ejecutado localmente
- [x] Tests locales y de CI pasan
- [x] Linter y formato aplicados
- [x] No hay console.logs ni código comentado innecesario
- [x] Manejo de errores y validaciones cubiertos
- [ ] Documentación/README actualizados
- [ ] Migraciones / cambios en DB revisados

---

## 🧾 Pruebas realizadas

**Pruebas manuales:**
- ✅ Endpoint responde correctamente con datos agrupados
- ✅ Categorías sin platos retornan array vacío
- ✅ Manejo de errores cuando la base de datos no está disponible
- ✅ Validación de estructura de respuesta JSON

**Resultados esperados vs obtenidos:**
- ✅ La agrupación funciona correctamente según la relación `category_id` en dishes
- ✅ Performance aceptable con datasets de prueba

**Riesgos detectados:**
- Ninguno crítico. Considerar paginación si el menú crece significativamente.

---

## ⚔️ Conflictos o consideraciones

- No se detectaron conflictos de merge con `main`
- Este endpoint complementa los existentes sin afectar funcionalidad actual
- Considerar agregar parámetros de consulta opcionales en el futuro (ej: `?active=true` para filtrar solo platos disponibles)

---

## 🧭 Notas para el revisor

**Puntos a revisar:**
- Validar la eficiencia de la consulta SQL/ORM utilizada para agrupar (verificar si hay N+1 queries)
- Revisar el manejo de errores en el servicio y controlador
- Confirmar que la estructura de respuesta cumple con las convenciones del proyecto

**Áreas que necesitan pruebas adicionales:**
- Performance con gran volumen de datos (100+ platos, 20+ categorías)
- Comportamiento cuando no existen categorías en la base de datos

**Tiempo estimado para probar manualmente:** 5-10 minutos

---

## 🔗 Referencias
- Issue relacionado: #10 